### PR TITLE
Fix crash on macOS due to dos:hidden attribute

### DIFF
--- a/src/main/java/supercoder79/simplexterrain/client/GoVote.java
+++ b/src/main/java/supercoder79/simplexterrain/client/GoVote.java
@@ -41,7 +41,9 @@ public class GoVote {
         try {
             Path path = Paths.get(MARKER_PATH);
             Files.createFile(path);
-            Files.setAttribute(path, "dos:hidden", true);
+            if (Util.getOperatingSystem() == Util.OperatingSystem.WINDOWS) {
+                Files.setAttribute(path, "dos:hidden", true);
+            }
         } catch (IOException ex) {
             markerAlreadyExists = true;
             return;


### PR DESCRIPTION
See https://github.com/Vazkii/Botania/commit/756b91badebf5e33339cfaeb812cacf34c3036ee, crash log https://paste.ee/p/34Ekz (from a similar mod)